### PR TITLE
Python venv initialization error on Ubuntu 14.04 and newer

### DIFF
--- a/s001-install/instalace.html
+++ b/s001-install/instalace.html
@@ -123,7 +123,7 @@ $ python3 -m venv venv
 $ virtualenv -p python3 venv
 </pre>
                 </div>
-                <div http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu>
+                <div class="col-lg-12">
                     <p>
                        Pokud používáme Ubuntu 14.04 nebo novější tak se může stát, že inicializace prostředí selže, pak je potřeba postupovat podle <a href="http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu">rady na askubuntu.com</a>, nebo provést následující příkazy.
                     </p>

--- a/s001-install/instalace.html
+++ b/s001-install/instalace.html
@@ -123,6 +123,16 @@ $ python3 -m venv venv
 $ virtualenv -p python3 venv
 </pre>
                 </div>
+                <div http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu>
+                    <p>
+                       Pokud používáme Ubuntu 14.04 nebo novější tak se může stát, že inicializace prostředí selže, pak je potřeba postupovat podle <a href="http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu">http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu</a> 
+                    </p>
+<pre>
+$ cp -r /usr/local/lib/python2.7/site-packages/ /tmp/site-packages
+$ sudo rm -rf /usr/local/lib/python2.7/site-packages/
+$ virtualenv --no-site-packages --distribute -p /usr/bin/python3 venv
+</pre>
+                </div>
                 <div class="col-lg-12">
                     <p>
                         Tím se nám vytvořil adresář <code><span class="plhome">~/pyladies</span>/venv</code>,

--- a/s001-install/instalace.html
+++ b/s001-install/instalace.html
@@ -125,7 +125,7 @@ $ virtualenv -p python3 venv
                 </div>
                 <div http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu>
                     <p>
-                       Pokud používáme Ubuntu 14.04 nebo novější tak se může stát, že inicializace prostředí selže, pak je potřeba postupovat podle <a href="http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu">http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu</a> 
+                       Pokud používáme Ubuntu 14.04 nebo novější tak se může stát, že inicializace prostředí selže, pak je potřeba postupovat podle <a href="http://askubuntu.com/questions/279959/how-to-create-a-virtualenv-with-python3-3-in-ubuntu">rady na askubuntu.com</a>, nebo provést následující příkazy.
                     </p>
 <pre>
 $ cp -r /usr/local/lib/python2.7/site-packages/ /tmp/site-packages


### PR DESCRIPTION
Solution for Python venv initialization error on Ubuntu 14.04 and newer added with link to askubuntu.com and fast fix of problem itself.
