### PR TITLE
Add missing pyglet.window.key import

### DIFF
--- a/v1/s012-pyglet/pong.html
+++ b/v1/s012-pyglet/pong.html
@@ -371,6 +371,7 @@ def vykresli():
                     <div>
 <details class="solution notes"><h4>Řešení</h4>
 <pre>
+from pyglet.window import key
 ...
 def stisk_klavesy(symbol, modifikatory):
     if symbol == key.W:


### PR DESCRIPTION
While brainlessly copying the materials I found something is missing.
